### PR TITLE
[WIP] Add AROSv1 x86_64 Docker recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MorphOS 3.9+ | MorphOS Team SDK 3.14 - gcc 9 | **Yes**
 
 Example for AROSv1 x86_64
 
-docker build -t "aros:arosv1-cross-toolchain" --rm -f x86_64-aros.docker .
+docker build -t "amigadev/crosstools:x86_64-aros." --rm -f x86_64-aros.docker .
 
 For other toolchains, use the appropriate Dockerfile:
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # AmigDev Docker Crosstools
 
-Currently AmigaOS 3.x, AmigaOS 4.x and MorphOS 3.9+ are supported. 
+Currently AmigaOS 3.x, AmigaOS 4.x and MorphOS 3.9+ are supported.
 WarpOS and AROS will get supported in the forseeable future
 
 ## Supported toolchains
-Platform | Toolchain | Supported 
+Platform | Toolchain | Supported
 ------------ | ------------ | -------------
 AmigaOS 3.x | @bebbo toolchain - gcc 6 | **Yes**
 AmigaOS 4.x | @sba1 adtools - gcc 8 | **Yes**
@@ -12,34 +12,77 @@ MorphOS 3.9+ | MorphOS Team (un)official tools - gcc 6 | **Yes**
 ~WarpOS~ | ~gcc 6~ | Not yet
 ~AROS ABIv1 x86_64~ | ~AROS Team Official - gcc 9~ | Not yet
 ~AROS ABIv1 x86~ | ~AROS Team Official - gcc 9~ | Not yet
+~AROS ABIv0 x86~ | ~AROS Team Official - gcc 9~ | Not yet
 ~AROS ABIv1 ARM BE (RasPi)~ | ~AROS Team Official - gcc 9~ | Not yet
 
+## Build the Docker container
+
+Example for AROSv1 x86_64
+
+docker build -t "aros:arosv1-cross-toolchain" --rm -f x86_64-aros.docker .
+
+For other toolchains, use the appropriate Dockerfile:
+
+- AmigaOS 3.x (M680x0): m68k-amigaos.docker
+
+- AmigaOS 4.x (PPC): ppc-amigaos.docker
+
+- MorphOS (PPC): ppc-morphos.docker
+
+## Run the Docker container for compiling a third party application
 
 ### AmigaOS4.x example:
 ```bash
-docker run --rm \
-	-v ${PWD}:/work \
-	-v /path/to/extra/ppc-amigaos/lib:/tools/usr/lib \
-	-v /path/to/extra/ppc-amigaos/include:/tools/usr/include \
-	-it amigadev/crosstools:ppc-amigaos bash
+docker run
+
+    # Destroy the container, once exited.
+    # Comment this line out if you want to keep container after execution
+    # for debugging
+    --rm \
+
+    # expose to the container the following local directories
+    # format is:
+    # <local_dir>:<container_dir>
+    -v ${PWD}:/work \
+    -v /path/to/extra/ppc-amigaos/lib:/tools/usr/lib \
+    -v /path/to/extra/ppc-amigaos/include:/tools/usr/include \
+
+    # Pass current UID and GID to container, so that it can change the
+    # ownership of output files which are otherwise writen to outdir as
+    # root
+    -e USER=$( id -u ) -e GROUP=$( id -g ) \
+
+    # Use this Docker image and then enter into it using the shell
+    -it amigadev/crosstools:ppc-amigaos /bin/bash
 ```
 
 ### AmigaOS3.x example
 ```bash
 docker run --rm \
-	-v ${PWD}:/work \
-	-v /path/to/extra/m68k-amigaos/lib:/tools/usr/lib \
-	-v /path/to/extra/m68k-amigaos/include:/tools/usr/include \
-	-it amigadev/crosstools:m68k-amigaos bash
+    -v ${PWD}:/work \
+    -v /path/to/extra/m68k-amigaos/lib:/tools/usr/lib \
+    -v /path/to/extra/m68k-amigaos/include:/tools/usr/include \
+    -e USER=$( id -u ) -e GROUP=$( id -g ) \
+    -it amigadev/crosstools:m68k-amigaos bash
 ```
 
 ### MorphOS example
 ```bashS
 docker run --rm \
-	-v ${PWD}:/work \
-	-v /path/to/extra/ppc-morphos/lib:/tools/usr/lib \
-	-v /path/to/extra/ppc-morphos/include:/tools/usr/include \
-	-it amigadev/crosstools:ppc-morphos bash
+    -v ${PWD}:/work \
+    -v /path/to/extra/ppc-morphos/lib:/tools/usr/lib \
+    -v /path/to/extra/ppc-morphos/include:/tools/usr/include \
+    -e USER=$( id -u ) -e GROUP=$( id -g ) \
+    -it amigadev/crosstools:ppc-morphos bash
+```
+
+### ArosV1 x86_64 example
+```bashS
+docker run --rm \
+    -v ${PWD}:/work \
+    -v /tmp/aros:/tmp/aros \
+    -e USER=$( id -u ) -e GROUP=$( id -g ) \
+    -it aros:arosv1-cross-toolchain bash
 ```
 
 * *${PWD}* is the current dir

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MorphOS 3.9+ | MorphOS Team SDK 3.14 - gcc 9 | **Yes**
 
 Example for AROSv1 x86_64
 
-docker build -t "amigadev/crosstools:x86_64-aros." --rm -f x86_64-aros.docker .
+docker build -t "amigadev/crosstools:x86_64-aros" --rm -f x86_64-aros.docker .
 
 For other toolchains, use the appropriate Dockerfile:
 
@@ -76,13 +76,13 @@ docker run --rm \
     -it amigadev/crosstools:ppc-morphos bash
 ```
 
-### ArosV1 x86_64 example
+### AROS (v1) x86_64 example
 ```bashS
 docker run --rm \
     -v ${PWD}:/work \
     -v /tmp/aros:/tmp/aros \
     -e USER=$( id -u ) -e GROUP=$( id -g ) \
-    -it aros:arosv1-cross-toolchain bash
+    -it amigadev/crosstools:x86_64-aros bash
 ```
 
 * *${PWD}* is the current dir

--- a/x86_64-aros.docker
+++ b/x86_64-aros.docker
@@ -1,12 +1,18 @@
 FROM amigadev/arosv1-cross-toolchain:x86_64 as build-env
 
-ENV CROSS_PFX x86_64-aros
-ENV CROSS_ROOT /opt/${CROSS_PFX}
+FROM amigadev/docker-base:latest
 
-COPY --from=build-env /opt/${CROSS_PFX} ./opt/${CROSS_PFX}
+ENV CROSS_PFX x86_64-aros
+ENV OS_NAME AROS
+
+COPY --from=build-env /opt/${CROSS_PFX} /opt/${CROSS_PFX}
 
 # START COMMON
 MAINTAINER Marlon Beijer "marlon@amigadev.com"
+RUN apt purge -y gcc g++ flex bison gettext texinfo binutils libgmp-dev libmpfr-dev libmpc-dev libncurses-dev && apt autoremove -y
+RUN echo "root:root" | chpasswd
+RUN ln -s /opt/${CROSS_PFX} /tools
+ENV CROSS_ROOT /opt/${CROSS_PFX}
 
 WORKDIR /work
 ENTRYPOINT ["/entry/entrypoint.sh"]
@@ -16,15 +22,24 @@ COPY imagefiles/ccmake.sh /usr/local/bin/ccmake
 COPY imagefiles/entrypoint.sh /entry/
 
 ENV AS=${CROSS_ROOT}/bin/${CROSS_PFX}-as \
-    LD=${CROSS_ROOT}/bin/${CROSS_PFX}-ld \
-    AR=${CROSS_ROOT}/bin/${CROSS_PFX}-ar \
-    CC=${CROSS_ROOT}/bin/${CROSS_PFX}-gcc \
-    CXX=${CROSS_ROOT}/bin/${CROSS_PFX}-g++ \
-    RANLIB=${CROSS_ROOT}/bin/${CROSS_PFX}-ranlib
+	LD=${CROSS_ROOT}/bin/${CROSS_PFX}-ld \
+	AR=${CROSS_ROOT}/bin/${CROSS_PFX}-ar \
+	CC=${CROSS_ROOT}/bin/${CROSS_PFX}-gcc \
+	CXX=${CROSS_ROOT}/bin/${CROSS_PFX}-g++ \
+	RANLIB=${CROSS_ROOT}/bin/${CROSS_PFX}-ranlib
+
+RUN ln -sf ${CROSS_ROOT}/bin/${CROSS_PFX}-as /usr/bin/as && \
+	ln -sf ${CROSS_ROOT}/bin/${CROSS_PFX}-ar /usr/bin/ar && \
+	ln -sf ${CROSS_ROOT}/bin/${CROSS_PFX}-ld /usr/bin/ld && \
+	ln -sf ${CROSS_ROOT}/bin/${CROSS_PFX}-gcc /usr/bin/gcc && \
+	ln -sf ${CROSS_ROOT}/bin/${CROSS_PFX}-g++ /usr/bin/g++ && \
+	ln -sf ${CROSS_ROOT}/bin/${CROSS_PFX}-ranlib /usr/bin/ranlib
 
 COPY dependencies/toolchains/${CROSS_PFX}.cmake ${CROSS_ROOT}/lib/
+COPY dependencies/toolchains/Modules/${CROSS_PFX} /CMakeModules
+RUN mv -fv /CMakeModules/* /usr/share/cmake-`cmake --version|awk '{ print $3;exit }'|awk -F. '{print $1"."$2}'`/Modules/
+RUN ln -s /usr/share/cmake-`cmake --version|awk '{ print $3;exit }'|awk -F. '{print $1"."$2}'`/Modules/Platform/Generic.cmake /usr/share/cmake-`cmake --version|awk '{ print $3;exit }'|awk -F. '{print $1"."$2}'`/Modules/Platform/${OS_NAME}.cmake
 ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/lib/${CROSS_PFX}.cmake
 ENV CMAKE_PREFIX_PATH /opt/${CROSS_PFX}:/opt/${CROSS_PFX}/usr
 ENV PATH ${PATH}:${CROSS_ROOT}/bin
-
 # END COMMON

--- a/x86_64-aros.docker
+++ b/x86_64-aros.docker
@@ -3,6 +3,8 @@ FROM amigadev/arosv1-cross-toolchain:x86_64 as build-env
 ENV CROSS_PFX x86_64-aros
 ENV CROSS_ROOT /opt/${CROSS_PFX}
 
+COPY --from=build-env /opt/${CROSS_PFX} ./opt/${CROSS_PFX}
+
 # START COMMON
 MAINTAINER Marlon Beijer "marlon@amigadev.com"
 
@@ -14,12 +16,12 @@ COPY imagefiles/ccmake.sh /usr/local/bin/ccmake
 COPY imagefiles/entrypoint.sh /entry/
 
 ENV AS=${CROSS_ROOT}/bin/${CROSS_PFX}-as \
-	LD=${CROSS_ROOT}/bin/${CROSS_PFX}-ld \
+    LD=${CROSS_ROOT}/bin/${CROSS_PFX}-ld \
     AR=${CROSS_ROOT}/bin/${CROSS_PFX}-ar \
     CC=${CROSS_ROOT}/bin/${CROSS_PFX}-gcc \
     CXX=${CROSS_ROOT}/bin/${CROSS_PFX}-g++ \
-	RANLIB=${CROSS_ROOT}/bin/${CROSS_PFX}-ranlib
-	
+    RANLIB=${CROSS_ROOT}/bin/${CROSS_PFX}-ranlib
+
 COPY dependencies/toolchains/${CROSS_PFX}.cmake ${CROSS_ROOT}/lib/
 ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/lib/${CROSS_PFX}.cmake
 ENV CMAKE_PREFIX_PATH /opt/${CROSS_PFX}:/opt/${CROSS_PFX}/usr

--- a/x86_64-aros.docker
+++ b/x86_64-aros.docker
@@ -1,6 +1,4 @@
-FROM amigadev/morphos-cross-toolchain:latest as build-env
-
-FROM amigadev/docker-base:latest
+FROM amigadev/arosv1-cross-toolchain:latest as build-env
 
 ENV CROSS_PFX x86_64-aros
 ENV CROSS_ROOT /opt/${CROSS_PFX}
@@ -8,20 +6,7 @@ ENV CROSS_ROOT /opt/${CROSS_PFX}
 # START COMMON
 MAINTAINER Marlon Beijer "marlon@amigadev.com"
 
-RUN apt update && apt install -y python-pip genisoimage wget curl git make automake autoconf pkg-config unzip gcc-multilib libtool zlib1g g++ libpng-dev libx11-dev libxcursor-dev libgl1-mesa-dev gawk bison flex netpbm cmake gperf libswitch-perl libasound2-dev python-mako
-# RUN apt install -y zzlib1g-dev
-RUN echo "root:root" | chpasswd
-
-RUN ln -s /usr/bin/genisoimage /usr/local/bin/mkisofs
-
-# Install proper LHA
-RUN cd /tmp/ && git clone https://github.com/AmigaPorts/lha.git && cd lha && autoreconf -is && ./configure && make && make check && make install
-
-# Install xdftool
-RUN pip install amitools
-
 WORKDIR /work
-
 ENTRYPOINT ["/entry/entrypoint.sh"]
 
 COPY imagefiles/cmake.sh /usr/local/bin/cmake

--- a/x86_64-aros.docker
+++ b/x86_64-aros.docker
@@ -1,0 +1,43 @@
+FROM amigadev/morphos-cross-toolchain:latest as build-env
+
+FROM amigadev/docker-base:latest
+
+ENV CROSS_PFX x86_64-aros
+ENV CROSS_ROOT /opt/${CROSS_PFX}
+
+# START COMMON
+MAINTAINER Marlon Beijer "marlon@amigadev.com"
+
+RUN apt update && apt install -y python-pip genisoimage wget curl git make automake autoconf pkg-config unzip gcc-multilib libtool zlib1g g++ libpng-dev libx11-dev libxcursor-dev libgl1-mesa-dev gawk bison flex netpbm cmake gperf libswitch-perl libasound2-dev python-mako
+# RUN apt install -y zzlib1g-dev
+RUN echo "root:root" | chpasswd
+
+RUN ln -s /usr/bin/genisoimage /usr/local/bin/mkisofs
+
+# Install proper LHA
+RUN cd /tmp/ && git clone https://github.com/AmigaPorts/lha.git && cd lha && autoreconf -is && ./configure && make && make check && make install
+
+# Install xdftool
+RUN pip install amitools
+
+WORKDIR /work
+
+ENTRYPOINT ["/entry/entrypoint.sh"]
+
+COPY imagefiles/cmake.sh /usr/local/bin/cmake
+COPY imagefiles/ccmake.sh /usr/local/bin/ccmake
+COPY imagefiles/entrypoint.sh /entry/
+
+ENV AS=${CROSS_ROOT}/bin/${CROSS_PFX}-as \
+	LD=${CROSS_ROOT}/bin/${CROSS_PFX}-ld \
+    AR=${CROSS_ROOT}/bin/${CROSS_PFX}-ar \
+    CC=${CROSS_ROOT}/bin/${CROSS_PFX}-gcc \
+    CXX=${CROSS_ROOT}/bin/${CROSS_PFX}-g++ \
+	RANLIB=${CROSS_ROOT}/bin/${CROSS_PFX}-ranlib
+	
+COPY dependencies/toolchains/${CROSS_PFX}.cmake ${CROSS_ROOT}/lib/
+ENV CMAKE_TOOLCHAIN_FILE ${CROSS_ROOT}/lib/${CROSS_PFX}.cmake
+ENV CMAKE_PREFIX_PATH /opt/${CROSS_PFX}:/opt/${CROSS_PFX}/usr
+ENV PATH ${PATH}:${CROSS_ROOT}/bin
+
+# END COMMON

--- a/x86_64-aros.docker
+++ b/x86_64-aros.docker
@@ -1,4 +1,4 @@
-FROM amigadev/arosv1-cross-toolchain:latest as build-env
+FROM amigadev/arosv1-cross-toolchain:x86_64 as build-env
 
 ENV CROSS_PFX x86_64-aros
 ENV CROSS_ROOT /opt/${CROSS_PFX}


### PR DESCRIPTION
Here is the recipe Dockerfile for AROS. 

Here I've basically merged one the other Dockeffile recipes with a previous version of the [docker-base recipe](https://github.com/AmigaPorts/docker-base/blob/8a49fe7a1d53b7fe75a0d23eaf28d166f1e44a7a/Dockerfile).

If I understand correctly all the system packages installaton are now in the docker-base Dockerfile (which you updated in commit https://github.com/AmigaPorts/docker-base/commit/8a49fe7a1d53b7fe75a0d23eaf28d166f1e44a7a), so they can be removed from this image, right?

I'm not really sure of what I am doing, the whole building workflow is still not clear, so thanks for helping me understand :-)

Thanks!